### PR TITLE
Fix: "피드댓글 수정"

### DIFF
--- a/src/main/java/com/kitri/bark_meow_party_server/controller/FeedCommentController.java
+++ b/src/main/java/com/kitri/bark_meow_party_server/controller/FeedCommentController.java
@@ -15,20 +15,21 @@ public class FeedCommentController {
     private FeedCommentService feedCommentService;
     //피드에 대한 댓글을 작성 하기 위한 컨트롤러
     @PostMapping("/feeds/{feedId}/comments")
-    public FeedComment addFeedComment(@RequestBody FeedComment feedComment) {
-        feedCommentService.addFeedComment(feedComment);
+    public FeedComment addFeedComment(@PathVariable Long feedId, @RequestBody FeedComment feedComment) {
+        feedCommentService.addFeedComment(feedId, feedComment);
         return feedComment;
     }
     //피드에 대한 댓글을 조회 하기 위한 컨트롤러
     @GetMapping("/feeds/{feedId}/comments")
-    public List<FeedComment> getFeedComments(@PathVariable int feedId) {
-        return feedCommentService.getFeedComments();
+    public List<FeedComment> getFeedComments(@PathVariable Long feedId) {
+        return feedCommentService.getFeedCommentsByFeedId(feedId);
     }
     //피드에 대한 댓글을 수정 하기 위한 컨트롤러
     @PutMapping("/feeds/{feedId}/comments/{commentId}")
     public FeedComment updateFeedComment(@RequestBody FeedComment feedComment,
                                              @PathVariable long feedId, @PathVariable long commentId) {
         feedComment.setFeedId(feedId);
+        feedComment.setId(commentId);
         feedCommentService.updateFeedComment(feedComment);
         return feedComment;
     }

--- a/src/main/java/com/kitri/bark_meow_party_server/domain/FeedComment.java
+++ b/src/main/java/com/kitri/bark_meow_party_server/domain/FeedComment.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Setter
 public class FeedComment {
     private Long id;
+    private Long userId;
     private Long feedId;
     private String content;
     private LocalDateTime createdAt;

--- a/src/main/java/com/kitri/bark_meow_party_server/mapper/FeedCommentMapper.java
+++ b/src/main/java/com/kitri/bark_meow_party_server/mapper/FeedCommentMapper.java
@@ -13,15 +13,19 @@ public interface FeedCommentMapper {
     List<FeedComment> selectAll();
 
     //주어진 ID에 해당하는 피드에 대한 댓글 조회
+    @Select("SELECT * FROM feed_comment WHERE feed_id = #{feedId}")
+    List<FeedComment> selectByFeedId(Long feedId);
+
+    //특정 ID 댓글 조회
     @Select("SELECT * FROM feed_comment WHERE id = #{id}")
     FeedComment selectById(Long id);
 
     //피드에 대한 댓글 추가
-    @Insert("INSERT INTO FeedComment(feed_id, content, create_at) VALUES (#{feed_id}, #{content}, #{create_at})")
+    @Insert("INSERT INTO feed_comment(feed_id, user_id, content, created_at) VALUES (#{feedId}, #{userId}, #{content}, NOW())")
     void feedCommentInsert(FeedComment comment);
 
     //주어진 ID에 해당하는 피드에 대한 댓글 수정
-    @Update("UPDATE FeedComment SET content=#{content} WHERE id=#{id}")
+    @Update("UPDATE feed_comment SET content=#{content} WHERE id=#{id}")
     void feedCommentUpdate(FeedComment comment);
 
     //주어진 ID에 해당하는 피드에 대한 댓글 삭제

--- a/src/main/java/com/kitri/bark_meow_party_server/service/FeedCommentService.java
+++ b/src/main/java/com/kitri/bark_meow_party_server/service/FeedCommentService.java
@@ -1,8 +1,12 @@
 package com.kitri.bark_meow_party_server.service;
 
 import com.kitri.bark_meow_party_server.domain.FeedComment;
+import com.kitri.bark_meow_party_server.domain.User;
 import com.kitri.bark_meow_party_server.mapper.FeedCommentMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -13,16 +17,26 @@ public class FeedCommentService {
     //FeedCommentMapper를 통해 데이터베이스 작업을 수행
     @Autowired //FeedCommentMapper 자동 의존성 주입
     FeedCommentMapper feedCommentMapper;
+    @Autowired
+    UserService userService;
     //모든 피드 댓글을 조회
     public List<FeedComment> getFeedComments() {
         return feedCommentMapper.selectAll();
     }
     //주어진 ID에 해당하는 피드 댓글을 조회
-    public FeedComment getFeedComment(Long id) {
-        return feedCommentMapper.selectById(id);
+    public List<FeedComment> getFeedCommentsByFeedId(Long feedId) {
+        return feedCommentMapper.selectByFeedId(feedId);
     }
     //새 피드 댓글을 데이터베이스에 추가
-    public void addFeedComment(FeedComment feedComment) {
+    public void addFeedComment(Long feedId, FeedComment feedComment) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = ((UserDetails) auth.getPrincipal()).getUsername();
+
+        User user = userService.findByUsername(username);
+
+        feedComment.setUserId(user.getId());
+        feedComment.setFeedId(feedId);
+
         feedComment.setCreatedAt(LocalDateTime.now());
         feedCommentMapper.feedCommentInsert(feedComment);
     }


### PR DESCRIPTION
피드댓글 CRUD 테스트 하고 잘못 된 부분 수정, mapper에서 test_id=#{test_id}이런 식으로 되어 있던 거 test_id=#{testId}이런식으로 변경, service에서 새 댓글 추가부분 userId랑 feedId 자동으로 값가져오게 수정 등